### PR TITLE
Change to name to more accurate for the contents

### DIFF
--- a/modules/local/validate_taxids.nf
+++ b/modules/local/validate_taxids.nf
@@ -7,7 +7,7 @@ process VALIDATE_TAXIDS {
         'genomicmedicinesweden/gmsmetapost:latest' }"
 
     input:
-    tuple val(meta), path(tsv), path(blastdb)
+    tuple val(meta), path(fastq), path(blastdb)
 
     output:
     tuple val(meta), path('*excludable_taxids.txt'), emit: txt


### PR DESCRIPTION
What is in the second element of the tuple is actually fastq file(s) and not a tsv file so this PR fixes that tiny issue.