### PR TITLE
Change container version to the currently used one

### DIFF
--- a/modules/local/remove_missing_taxids.nf
+++ b/modules/local/remove_missing_taxids.nf
@@ -3,7 +3,7 @@ process REMOVE_MISSING_TAXIDS {
 
     conda (params.enable_conda ? "conda-forge::python>=3.9 conda-forge::parallel=20220722 " : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'library://ljmesi/gmsmetapost/datasets_pydantic:20220815' :
+        'library://ljmesi/gmsmetapost/general:20220901' :
         'genomicmedicinesweden/gmsmetapost:latest' }"
 
     input:

--- a/modules/local/validate_taxids.nf
+++ b/modules/local/validate_taxids.nf
@@ -3,7 +3,7 @@ process VALIDATE_TAXIDS {
 
     conda (params.enable_conda ? "conda-forge::python>=3.9 bioconda::blast=2.13.0 conda-forge::parallel=20220722 " : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'library://ljmesi/gmsmetapost/datasets_pydantic:20220815' :
+        'library://ljmesi/gmsmetapost/general:20220901' :
         'genomicmedicinesweden/gmsmetapost:latest' }"
 
     input:


### PR DESCRIPTION
The version of singularity container that contains the currently used programs is `general:20220901`. This small PR fixes the names in two local modules. This change is only useful for the time being before docker containers are used for both singularity and docker profiles.