### PR TITLE
Resolve bam

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -48,7 +48,7 @@ process {
         publishDir = [
             enabled: false
         ]
-        ext.args2 = "--require-flags 4"
+        ext.args2 = "-F 4"
     }
 
     withName: MINIMAP2_INDEX {
@@ -61,7 +61,7 @@ process {
         publishDir = [
             enabled: false
         ]
-        ext.args2 = "-f 4"
+        ext.args2 = "-F 4"
     }
 
     withName: FASTQC {

--- a/modules/local/bwa/mem/main.nf
+++ b/modules/local/bwa/mem/main.nf
@@ -1,6 +1,6 @@
 process BWA_MEM {
     tag "${meta.sample}: ${meta.taxid}"
-    label 'process_high'
+    label 'process_medium'
 
     conda (params.enable_conda ? "bioconda::bwa=0.7.17 bioconda::samtools=1.15.1" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
This PR fixes the issue of the empty bam/coverage depth files. The samtools view parameter is changed from `-f 4` to `-F 4` to retain mapped reads only.